### PR TITLE
In progress wait fix roles

### DIFF
--- a/deploy/operator.template.yaml
+++ b/deploy/operator.template.yaml
@@ -60,6 +60,12 @@ objects:
           - create
           - watch
       - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - list
+      - apiGroups:
           - kafka.strimzi.io
         resources:
           - kafkas

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -150,6 +150,14 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 			log.Error(err, "error reconciling installation instance")
 			return reconcile.Result{}, err
 		}
+
+		// if phase is still in progress, ensure it's requeued until its completed.
+		if string(phase) == string(v1alpha1.PhaseInProgress) {
+			return reconcile.Result{
+				Requeue: true,
+			}, nil
+		}
+
 		//don't move to next stage until current stage is finished
 		break
 	}

--- a/pkg/controller/installation/marketplace/manager.go
+++ b/pkg/controller/installation/marketplace/manager.go
@@ -11,6 +11,8 @@ import (
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var providerLabel = "opsrc-provider"
+
 type operatorSources struct {
 	Redhat marketplacev1.OperatorSource
 }
@@ -18,6 +20,11 @@ type operatorSources struct {
 func GetOperatorSources() *operatorSources {
 	return &operatorSources{
 		Redhat: marketplacev1.OperatorSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					providerLabel: "redhat",
+				},
+			},
 			Spec: marketplacev1.OperatorSourceSpec{
 				DisplayName: "Red Hat Operators",
 				Publisher:   "Red Hat",
@@ -56,7 +63,7 @@ func (m *MarketplaceManager) CreateSubscription(os marketplacev1.OperatorSource,
 
 	csc := &marketplacev1.CatalogSourceConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "installed-" + pkg + "-" + ns,
+			Name:      "installed-" + os.Labels[providerLabel] + "-" + ns,
 			Namespace: "openshift-marketplace",
 		},
 		Spec: marketplacev1.CatalogSourceConfigSpec{


### PR DESCRIPTION
The main change here is https://github.com/philbrookes/integreatly-operator/commit/9438352a5d3bef1a913c78803a006c659adb70f2

This version of the operator sdk doesn't reconcile periodically, only on updates to the CR, so when a product is "in progress" the CR state/status may stay the same on subsequent reconciles.
In that scenario the call to update doesn't kick off a reconcile loop.

The fix is to keep `Requeue`-ing until the product is deployed.

Other fixes:
- Updated the template so 3.11 deploy can list pods
- small marketplace change to match what the ui does